### PR TITLE
Persistent layouts on route change

### DIFF
--- a/src/layouts/SampleLayout.tsx
+++ b/src/layouts/SampleLayout.tsx
@@ -1,0 +1,14 @@
+import React, { useEffect, useState } from "react";
+
+interface SampleLayoutProps {}
+
+const SampleLayout: React.FC<SampleLayoutProps> = ({ children }) => {
+  return (
+    <div>
+      Sample layout!
+      <div>{children}</div>
+    </div>
+  );
+};
+
+export default SampleLayout;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,15 +3,24 @@ import { ApolloClient, InMemoryCache } from "@apollo/client";
 import { ApolloProvider } from "@apollo/client/react";
 import "tailwindcss/tailwind.css";
 
+import Page from "../types/Page";
+import { ReactElement } from "react";
+
 const client = new ApolloClient({
   uri: "http://localhost:4000/graphql",
   cache: new InMemoryCache(),
 });
 
-function MyApp({ Component, pageProps }: AppProps) {
+type CustomAppProps = AppProps & {
+  Component: Page;
+};
+
+function MyApp({ Component, pageProps }: CustomAppProps) {
+  const getLayout = Component.getLayout || ((page: ReactElement) => page);
+
   return (
     <ApolloProvider client={client}>
-      <Component {...pageProps} />
+      {getLayout(<Component {...pageProps} />)}
     </ApolloProvider>
   );
 }

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,0 +1,18 @@
+import React, { useEffect, useState } from "react";
+import SampleLayout from "../layouts/SampleLayout";
+import Link from "next/link";
+
+import Page from "../types/Page";
+
+interface HomePageProps {}
+const HomePage: Page<HomePageProps> = ({}) => {
+  return (
+    <div>
+      Home page. <Link href="/mentors">Go to mentors.</Link>
+    </div>
+  );
+};
+
+HomePage.getLayout = (page) => <SampleLayout>{page}</SampleLayout>;
+
+export default HomePage;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,13 @@
 import { useState } from "react";
 import { useGetUsersLazyQuery, useGetUsersQuery } from "../generated/graphql";
 
+const getSubdomain = () => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return window.location.href.split(".")[0].split("//")[1];
+};
+
 const IndexPage = () => {
   const [getUser, { loading, data }] = useGetUsersLazyQuery();
   const [text, setText] = useState("");

--- a/src/pages/mentors.tsx
+++ b/src/pages/mentors.tsx
@@ -1,0 +1,18 @@
+import React, { useEffect, useState } from "react";
+import SampleLayout from "../layouts/SampleLayout";
+import Link from "next/link";
+
+import Page from "../types/Page";
+
+interface HomePageProps {}
+const HomePage: Page<HomePageProps> = ({}) => {
+  return (
+    <div>
+      Mentors page. <Link href="/home">Go to home.</Link>
+    </div>
+  );
+};
+
+HomePage.getLayout = (page) => <SampleLayout>{page}</SampleLayout>;
+
+export default HomePage;

--- a/src/types/Page.d.ts
+++ b/src/types/Page.d.ts
@@ -1,0 +1,8 @@
+import { NextPage } from "next";
+import { ReactElement, ReactNode } from "react";
+
+type Page<P = {}> = NextPage<P> & {
+  getLayout?: (page: ReactElement) => ReactNode;
+};
+
+export default Page;


### PR DESCRIPTION
* SampleLayout component not rerendered on route change
* Modified default Next.js Page type to add .getLayout()

From this guide: https://adamwathan.me/2019/10/17/persistent-layout-patterns-in-nextjs/