### PR TITLE
Forgot Password Flow

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -119,6 +119,7 @@ const NoMentorshipHome: Page = () => {
             className="w-96 mt-9"
             onClick={() => {
               setIsCreateClicked(true);
+              console.log(isCreateClicked);
             }}
           >
             <Link href="/create">

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -94,7 +94,10 @@ const LoginPage = () => {
           <div>
             <div className="flex justify-between">
               <Text b>Password</Text>
-              <Text>TODO: Forgot password?</Text>
+
+              <Text className="text-darkblue hover:underline">
+                <Link href="/reset-password">Forgot Password?</Link>
+              </Text>
             </div>
             <div className="h-1" />
             <Input
@@ -106,7 +109,7 @@ const LoginPage = () => {
               onChange={(e) => {
                 setPassword(e.target.value);
               }}
-            ></Input>
+            />
           </div>
           <div className="h-6" />
 

--- a/src/pages/reset-password.tsx
+++ b/src/pages/reset-password.tsx
@@ -169,7 +169,7 @@ const SuccessfulReset = () => (
 
 const ResetPasswordPage: Page = () => {
   const [email, setEmail] = useState("");
-  const [stage, setStage] = useState(ResetPasswordStages.SuccessfulReset);
+  const [stage, setStage] = useState(ResetPasswordStages.InputEmail);
   const [error, setError] = useState("");
 
   const getStage = () => {

--- a/src/pages/reset-password.tsx
+++ b/src/pages/reset-password.tsx
@@ -1,0 +1,218 @@
+import React, { useState } from "react";
+import { Text, Input, Button } from "../components/atomic";
+// import TitledInput from "../components/TitledInput";
+import { useAuth } from "../utils/firebase/auth";
+import { validateEmail } from "../utils";
+import Link from "next/link";
+import Page from "../types/Page";
+
+enum ResetPasswordStages {
+  InputEmail = 0,
+  ResetPassword = 1,
+  SuccessfulReset = 2,
+}
+
+type ResetPasswordStageProps = {
+  email: string;
+  setEmail?: (email: string) => void;
+  setStage: (stage: ResetPasswordStages) => void;
+  setError: (error: string) => void;
+};
+
+//TODO: Customize Reset password pages using continueURL
+// const ResetPassword = ({
+//   email,
+//   setStage,
+//   setError,
+// }: ResetPasswordStageProps) => {
+//   const { sendPasswordResetEmail, confirmPasswordReset } = useAuth();
+//   const [code, setCode] = useState("");
+//   const [password0, setPassword0] = useState("");
+//   const [password1, setPassword1] = useState("");
+//   const [loading, setLoading] = useState(false);
+
+//   return (
+//     <>
+//       <Text>
+//         Check your email and type the code sent to you in the box below to
+//         verify your email address. Didn't receive the email?{" "}
+//         <button
+//           onClick={(_) =>
+//             sendPasswordResetEmail(email).then(() => {
+//               //loading logic
+//             })
+//           }
+//         >
+//           <Text b className="hover:underline text-darkblue">
+//             Resend the verification email
+//           </Text>
+//         </button>
+//         .
+//       </Text>
+//       <div className="h-4" />
+//       <TitledInput
+//         title="Verification Code"
+//         placeholder="Verification Code"
+//         value={code}
+//         onChange={(e) => {
+//           setCode(e.target.value);
+//         }}
+//       />
+//       <div className="h-4" />
+//       <TitledInput
+//         title="Password"
+//         placeholder="********"
+//         value={password0}
+//         onChange={(e) => {
+//           setPassword0(e.target.value);
+//         }}
+//       />
+//       <TitledInput
+//         title="Re-Enter Password"
+//         placeholder="********"
+//         value={password1}
+//         onChange={(e) => {
+//           setPassword1(e.target.value);
+//         }}
+//       />
+//       <div className="h-6" />
+//       <div className="flex justify-between">
+//         <Button
+//           disabled={loading}
+//           size="small"
+//           variant="inverted"
+//           onClick={() => {
+//             setError("");
+//             setStage(ResetPasswordStages.InputEmail);
+//           }}
+//         >
+//           Back
+//         </Button>
+//         <Button
+//           disabled={loading}
+//           size="small"
+//           onClick={(_) => {
+//             if (password0 === password1) {
+//               setLoading(true);
+//               confirmPasswordReset(code, password0).then(() => {
+//                 /* Success Message & Log in */
+//                 setError("");
+//                 setStage(ResetPasswordStages.SuccessfulReset);
+//                 setLoading(false);
+//               });
+//             } else {
+//               setError("Make sure the password fields match.");
+//             }
+//           }}
+//         >
+//           Reset Password
+//         </Button>
+//       </div>
+//     </>
+//   );
+// };
+
+const InputEmail = ({
+  email,
+  setEmail,
+  setStage,
+  setError,
+}: ResetPasswordStageProps) => {
+  const { sendPasswordResetEmail } = useAuth();
+
+  return (
+    <>
+      <Text>
+        Type in your email and we'll send a password reset email to you with a
+        code to reset your password.
+      </Text>
+      <div className="h-4" />
+      <Input
+        placeholder="example@example.com"
+        value={email}
+        onChange={(e) => {
+          setEmail!(e.target.value);
+        }}
+      />
+      <div className="h-4" />
+      <Button
+        size="small"
+        onClick={(_) => {
+          if (validateEmail(email)) {
+            sendPasswordResetEmail(email).then(() => {
+              setStage(ResetPasswordStages.SuccessfulReset);
+              setError("");
+            });
+          } else {
+            setError("Please provide a valid email.");
+          }
+        }}
+      >
+        Send Email
+      </Button>
+    </>
+  );
+};
+
+const SuccessfulReset = () => (
+  <>
+    <Text>
+      You should've received an email to reset your password. Once you've filled
+      out that form, you can log in again!
+    </Text>
+    <div className="h-4" />
+    <Link href="/login">
+      <Button size="small">Log in</Button>
+    </Link>
+  </>
+);
+
+const ResetPasswordPage: Page = () => {
+  const [email, setEmail] = useState("");
+  const [stage, setStage] = useState(ResetPasswordStages.SuccessfulReset);
+  const [error, setError] = useState("");
+
+  const getStage = () => {
+    switch (stage) {
+      case ResetPasswordStages.InputEmail:
+        return (
+          <InputEmail
+            email={email}
+            setEmail={setEmail}
+            setStage={setStage}
+            setError={setError}
+          />
+        );
+      // case ResetPasswordStages.ResetPassword:
+      //   return (
+      //     <ResetPassword
+      //       email={email}
+      //       setStage={setStage}
+      //       setError={setError}
+      //     />
+      //   );
+      case ResetPasswordStages.SuccessfulReset:
+        return <SuccessfulReset />;
+    }
+  };
+
+  return (
+    <div className="flex w-screen min-h-screen relative">
+      <img
+        src="/static/DarkTextLogo.svg"
+        className="absolute p-6 select-none pointer-events-none"
+      />
+      <div className="w-3/4 m-auto">
+        <Text h1 b>
+          Reset Password
+        </Text>
+        <div className="h-4" />
+        {getStage()}
+        <div className="h-4" />
+        <Text className="min-h-4 text-error">{error}</Text>
+      </div>
+    </div>
+  );
+};
+
+export default ResetPasswordPage;

--- a/src/pages/reset-password.tsx
+++ b/src/pages/reset-password.tsx
@@ -8,119 +8,18 @@ import Page from "../types/Page";
 
 enum ResetPasswordStages {
   InputEmail = 0,
-  ResetPassword = 1,
-  SuccessfulReset = 2,
+  SuccessfulReset = 1,
 }
 
-type ResetPasswordStageProps = {
-  email: string;
-  setEmail?: (email: string) => void;
-  setStage: (stage: ResetPasswordStages) => void;
-  setError: (error: string) => void;
-};
-
-//TODO: Customize Reset password pages using continueURL
-// const ResetPassword = ({
-//   email,
-//   setStage,
-//   setError,
-// }: ResetPasswordStageProps) => {
-//   const { sendPasswordResetEmail, confirmPasswordReset } = useAuth();
-//   const [code, setCode] = useState("");
-//   const [password0, setPassword0] = useState("");
-//   const [password1, setPassword1] = useState("");
-//   const [loading, setLoading] = useState(false);
-
-//   return (
-//     <>
-//       <Text>
-//         Check your email and type the code sent to you in the box below to
-//         verify your email address. Didn't receive the email?{" "}
-//         <button
-//           onClick={(_) =>
-//             sendPasswordResetEmail(email).then(() => {
-//               //loading logic
-//             })
-//           }
-//         >
-//           <Text b className="hover:underline text-darkblue">
-//             Resend the verification email
-//           </Text>
-//         </button>
-//         .
-//       </Text>
-//       <div className="h-4" />
-//       <TitledInput
-//         title="Verification Code"
-//         placeholder="Verification Code"
-//         value={code}
-//         onChange={(e) => {
-//           setCode(e.target.value);
-//         }}
-//       />
-//       <div className="h-4" />
-//       <TitledInput
-//         title="Password"
-//         placeholder="********"
-//         value={password0}
-//         onChange={(e) => {
-//           setPassword0(e.target.value);
-//         }}
-//       />
-//       <TitledInput
-//         title="Re-Enter Password"
-//         placeholder="********"
-//         value={password1}
-//         onChange={(e) => {
-//           setPassword1(e.target.value);
-//         }}
-//       />
-//       <div className="h-6" />
-//       <div className="flex justify-between">
-//         <Button
-//           disabled={loading}
-//           size="small"
-//           variant="inverted"
-//           onClick={() => {
-//             setError("");
-//             setStage(ResetPasswordStages.InputEmail);
-//           }}
-//         >
-//           Back
-//         </Button>
-//         <Button
-//           disabled={loading}
-//           size="small"
-//           onClick={(_) => {
-//             if (password0 === password1) {
-//               setLoading(true);
-//               confirmPasswordReset(code, password0).then(() => {
-//                 /* Success Message & Log in */
-//                 setError("");
-//                 setStage(ResetPasswordStages.SuccessfulReset);
-//                 setLoading(false);
-//               });
-//             } else {
-//               setError("Make sure the password fields match.");
-//             }
-//           }}
-//         >
-//           Reset Password
-//         </Button>
-//       </div>
-//     </>
-//   );
-// };
-
-const InputEmail = ({
-  email,
-  setEmail,
-  setStage,
-  setError,
-}: ResetPasswordStageProps) => {
+//TODO: Customize reset password pages with
+const ResetPasswordPage: Page = () => {
   const { sendPasswordResetEmail } = useAuth();
+  const [email, setEmail] = useState("");
+  const [stage, setStage] = useState(ResetPasswordStages.InputEmail);
+  const [error, setError] = useState("");
 
-  return (
+  //should be outside switch statement so input works
+  const InputEmail = () => (
     <>
       <Text>
         Type in your email and we'll send a password reset email to you with a
@@ -152,47 +51,24 @@ const InputEmail = ({
       </Button>
     </>
   );
-};
-
-const SuccessfulReset = () => (
-  <>
-    <Text>
-      You should've received an email to reset your password. Once you've filled
-      out that form, you can log in again!
-    </Text>
-    <div className="h-4" />
-    <Link href="/login">
-      <Button size="small">Log in</Button>
-    </Link>
-  </>
-);
-
-const ResetPasswordPage: Page = () => {
-  const [email, setEmail] = useState("");
-  const [stage, setStage] = useState(ResetPasswordStages.InputEmail);
-  const [error, setError] = useState("");
 
   const getStage = () => {
     switch (stage) {
       case ResetPasswordStages.InputEmail:
-        return (
-          <InputEmail
-            email={email}
-            setEmail={setEmail}
-            setStage={setStage}
-            setError={setError}
-          />
-        );
-      // case ResetPasswordStages.ResetPassword:
-      //   return (
-      //     <ResetPassword
-      //       email={email}
-      //       setStage={setStage}
-      //       setError={setError}
-      //     />
-      //   );
+        return <InputEmail />;
       case ResetPasswordStages.SuccessfulReset:
-        return <SuccessfulReset />;
+        return (
+          <>
+            <Text>
+              You should've received an email to reset your password. Once
+              you've filled out that form, you can log in again!
+            </Text>
+            <div className="h-4" />
+            <Link href="/login">
+              <Button size="small">Log in</Button>
+            </Link>
+          </>
+        );
     }
   };
 

--- a/src/pages/reset-password.tsx
+++ b/src/pages/reset-password.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import { Text, Input, Button } from "../components/atomic";
-// import TitledInput from "../components/TitledInput";
 import { useAuth } from "../utils/firebase/auth";
 import { validateEmail } from "../utils";
 import Link from "next/link";
@@ -12,65 +11,12 @@ enum ResetPasswordStages {
 }
 
 //TODO: Customize reset password pages with
+//TODO: Incorporate loading UI when resending link
 const ResetPasswordPage: Page = () => {
   const { sendPasswordResetEmail } = useAuth();
   const [email, setEmail] = useState("");
   const [stage, setStage] = useState(ResetPasswordStages.InputEmail);
   const [error, setError] = useState("");
-
-  //should be outside switch statement so input works
-  const InputEmail = () => (
-    <>
-      <Text>
-        Type in your email and we'll send a password reset email to you with a
-        code to reset your password.
-      </Text>
-      <div className="h-4" />
-      <Input
-        placeholder="example@example.com"
-        value={email}
-        onChange={(e) => {
-          setEmail!(e.target.value);
-        }}
-      />
-      <div className="h-4" />
-      <Button
-        size="small"
-        onClick={(_) => {
-          if (validateEmail(email)) {
-            sendPasswordResetEmail(email).then(() => {
-              setStage(ResetPasswordStages.SuccessfulReset);
-              setError("");
-            });
-          } else {
-            setError("Please provide a valid email.");
-          }
-        }}
-      >
-        Send Email
-      </Button>
-    </>
-  );
-
-  const getStage = () => {
-    switch (stage) {
-      case ResetPasswordStages.InputEmail:
-        return <InputEmail />;
-      case ResetPasswordStages.SuccessfulReset:
-        return (
-          <>
-            <Text>
-              You should've received an email to reset your password. Once
-              you've filled out that form, you can log in again!
-            </Text>
-            <div className="h-4" />
-            <Link href="/login">
-              <Button size="small">Log in</Button>
-            </Link>
-          </>
-        );
-    }
-  };
 
   return (
     <div className="flex w-screen min-h-screen relative">
@@ -83,7 +29,61 @@ const ResetPasswordPage: Page = () => {
           Reset Password
         </Text>
         <div className="h-4" />
-        {getStage()}
+        {stage === ResetPasswordStages.InputEmail ? (
+          <form>
+            <Text>
+              Type in your email and we'll send a link to reset your password
+              with.
+            </Text>
+            <div className="h-4" />
+            <Input
+              placeholder="example@example.com"
+              value={email}
+              onChange={(e) => {
+                setEmail!(e.target.value);
+              }}
+            />
+            <div className="h-4" />
+            <Button
+              type="submit"
+              size="small"
+              onClick={(e) => {
+                e.preventDefault();
+                if (validateEmail(email)) {
+                  sendPasswordResetEmail(email).then(() => {
+                    setStage(ResetPasswordStages.SuccessfulReset);
+                    setError("");
+                  });
+                } else {
+                  setError("Please provide a valid email.");
+                }
+              }}
+            >
+              Send Email
+            </Button>
+          </form>
+        ) : (
+          <>
+            <Text>
+              You should've received an email to reset your password. Once
+              you've filled out that form, you can log in again! Didn't receive
+              an email?{" "}
+              <button
+                onClick={() => {
+                  setStage(ResetPasswordStages.InputEmail);
+                }}
+              >
+                <Text className="text-darkblue hover:underline">
+                  Resend the link.
+                </Text>
+              </button>
+            </Text>
+            <div className="h-4" />
+            <Link href="/login">
+              <Button size="small">Log in</Button>
+            </Link>
+          </>
+        )}
         <div className="h-4" />
         <Text className="min-h-4 text-error">{error}</Text>
       </div>

--- a/src/utils/firebase/auth.tsx
+++ b/src/utils/firebase/auth.tsx
@@ -5,6 +5,9 @@ import firebase from "./firebase";
 interface AuthContext {
   user: firebase.User | null;
   loading: boolean;
+  //TODO: customize the forget password flow instead of directly through firebase's ugly ui
+  // confirmPasswordReset: (c: string, n: string) => Promise<void>;
+  sendPasswordResetEmail: (e: string) => Promise<void>;
   signUpWithEmail: (
     e: string,
     p: string
@@ -26,6 +29,14 @@ function useProvideAuth() {
   const clearCache = () => {
     client.resetStore();
     localStorage.clear();
+  };
+
+  // const confirmPasswordReset = (code: string, newPassword: string) => {
+  //   return firebase.auth().confirmPasswordReset(code, newPassword);
+  // };
+
+  const sendPasswordResetEmail = (email: string) => {
+    return firebase.auth().sendPasswordResetEmail(email);
   };
 
   const signUpWithEmail = async (email: string, password: string) => {
@@ -81,6 +92,8 @@ function useProvideAuth() {
   return {
     user,
     loading,
+    // confirmPasswordReset,
+    sendPasswordResetEmail,
     signUpWithEmail,
     signInWithEmail,
     signInWithGoogle,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -23,3 +23,10 @@ export function getTimezoneSelectOptions() {
     };
   });
 }
+
+const emailForm = new RegExp(
+  /^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/
+);
+export function validateEmail(email: string) {
+  return email && emailForm.test(email);
+}


### PR DESCRIPTION
There is a section of code that is commented out because I didn't understand what the firebase reset password link did at first. I think eventually we will want to alter the flow so that it goes to a continueURL (some page in our app) so I'm keeping the commented out code for now but on future iterations we can delete it.

Routes:
/reset-password
/login