### PR TITLE
Bugfixes

### DIFF
--- a/src/components/Availabilities/SetAvailabilityOverridesCard.tsx
+++ b/src/components/Availabilities/SetAvailabilityOverridesCard.tsx
@@ -4,6 +4,9 @@ import {
   format,
   getDay,
   isEqual,
+  setDate,
+  setMonth,
+  setYear,
   startOfDay,
 } from "date-fns";
 import React, { Fragment, useState } from "react";
@@ -214,9 +217,23 @@ const EditAvailOverrideDayModalContents = ({
             });
 
             setTimeslots(
-              availWeeklys.filter(
-                (avail) => avail.startTime.getDay() === weekday
-              )
+              availWeeklys
+                .filter((avail) => avail.startTime.getDay() === weekday)
+                .map((slot) => {
+                  const year = newSelectedDate.getFullYear();
+                  const month = newSelectedDate.getMonth();
+                  const date = newSelectedDate.getDate();
+                  return {
+                    startTime: setDate(
+                      setMonth(setYear(slot.startTime, year), month),
+                      date
+                    ),
+                    endTime: setDate(
+                      setMonth(setYear(slot.endTime, year), month),
+                      date
+                    ),
+                  };
+                })
             );
           }
         }}
@@ -493,7 +510,10 @@ export const SetAvailabilityOverridesCard = ({
           return (
             <React.Fragment key={idx}>
               <div className="w-full h-px bg-inactive" />
-              <AvailOverrideDateSection overrideDate={overrideDate} availWeeklys={availWeeklys} />
+              <AvailOverrideDateSection
+                overrideDate={overrideDate}
+                availWeeklys={availWeeklys}
+              />
             </React.Fragment>
           );
         })}

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -113,7 +113,7 @@ const LongTextAsker = ({
         placeholder={type === "short-answer" ? "Short text" : "Long text"}
         readOnly={readonly}
         disabled={readonly}
-        maxRows={readonly ? 2 : undefined}
+        maxRows={undefined}
         value={initResponse}
         onChange={(e: any) => {
           const target = e.target as HTMLTextAreaElement;


### PR DESCRIPTION
Bugs fixed:

* Auto-generated timeslots for date overrides were set on the wrong day
* Readonly forms had Textareas of maxHeight = 2 lines.